### PR TITLE
Fix infinite recursion in SimilarityMeasure

### DIFF
--- a/common/src/test/java/com/bakdata/dedupe/similarity/MatchingSimilarityTest.java
+++ b/common/src/test/java/com/bakdata/dedupe/similarity/MatchingSimilarityTest.java
@@ -90,4 +90,38 @@ class MatchingSimilarityTest {
                         / 5, offset(1e-4d)
         );
     }
+
+    @Test
+    void shouldHandleLeftNullValue() {
+        final List<String> men = Arrays.asList("aaa", "ddd", "bbb", "ccc");
+
+        final SimilarityMeasure<List<String>> stableMatching =
+                new MatchingSimilarity<>(new WeaklyStableMarriage<>(), levenshtein());
+
+        final double sim =
+                stableMatching.getSimilarity(null, men, SimilarityContext.builder().build());
+        assertThat(sim).isEqualTo(SimilarityMeasure.unknown());
+    }
+
+    @Test
+    void shouldHandleRightNullValue() {
+        final List<String> men = Arrays.asList("aaa", "ddd", "bbb", "ccc");
+
+        final SimilarityMeasure<List<String>> stableMatching =
+                new MatchingSimilarity<>(new WeaklyStableMarriage<>(), levenshtein());
+
+        final double sim =
+                stableMatching.getSimilarity(men, null, SimilarityContext.builder().build());
+        assertThat(sim).isEqualTo(SimilarityMeasure.unknown());
+    }
+
+    @Test
+    void shouldHandleTwoNullValue() {
+        final SimilarityMeasure<List<String>> stableMatching =
+                new MatchingSimilarity<>(new WeaklyStableMarriage<>(), levenshtein());
+
+        final double sim =
+                stableMatching.getSimilarity(null, null, SimilarityContext.builder().build());
+        assertThat(sim).isEqualTo(SimilarityMeasure.unknown());
+    }
 }

--- a/core/src/main/java/com/bakdata/dedupe/similarity/SimilarityContext.java
+++ b/core/src/main/java/com/bakdata/dedupe/similarity/SimilarityContext.java
@@ -46,12 +46,12 @@ public class SimilarityContext {
      */
     @Builder.Default
     @NonNull
-    SimilarityMeasure<Object> similarityMeasureForNull = (left, right, context) -> SimilarityMeasure.unknown();
+    SimilarityMeasure<Object> similarityMeasureForNull = new UnknownSimilarityMeasure<>();
 
     /**
      * Calculates the similarity when any of the two values under comparison is null.
      */
     public <T> double getSimilarityForNull(final T left, final T right, final SimilarityContext context) {
-        return this.similarityMeasureForNull.getNonNullSimilarity(left, right, context);
+        return this.similarityMeasureForNull.getSimilarity(left, right, context);
     }
 }

--- a/core/src/main/java/com/bakdata/dedupe/similarity/SimilarityContext.java
+++ b/core/src/main/java/com/bakdata/dedupe/similarity/SimilarityContext.java
@@ -52,6 +52,6 @@ public class SimilarityContext {
      * Calculates the similarity when any of the two values under comparison is null.
      */
     public <T> double getSimilarityForNull(final T left, final T right, final SimilarityContext context) {
-        return this.similarityMeasureForNull.getSimilarity(left, right, context);
+        return this.similarityMeasureForNull.getNonNullSimilarity(left, right, context);
     }
 }

--- a/core/src/main/java/com/bakdata/dedupe/similarity/UnknownSimilarityMeasure.java
+++ b/core/src/main/java/com/bakdata/dedupe/similarity/UnknownSimilarityMeasure.java
@@ -1,0 +1,16 @@
+package com.bakdata.dedupe.similarity;
+
+import lombok.NonNull;
+
+class UnknownSimilarityMeasure<T> implements SimilarityMeasure<T> {
+    @Override
+    public double getSimilarity(final Object left, final Object right, final @NonNull SimilarityContext context) {
+        return SimilarityMeasure.unknown();
+    }
+
+    @Override
+    public double getNonNullSimilarity(final @NonNull Object left, final @NonNull Object right,
+            final @NonNull SimilarityContext context) {
+        return SimilarityMeasure.unknown();
+    }
+}


### PR DESCRIPTION
Fixes #18 

This PR changes the null-handling behaviour in SimilarityContext to the apparently intended, but not implemented one. Additionally, we add further test cases that cover the handling of `null` values.
