### PR TITLE
Handle clusters with more than 128 elements

### DIFF
--- a/common/src/test/java/com/bakdata/dedupe/clustering/RefineClusterImplTest.java
+++ b/common/src/test/java/com/bakdata/dedupe/clustering/RefineClusterImplTest.java
@@ -1,8 +1,8 @@
 package com.bakdata.dedupe.clustering;
 
 import static com.bakdata.dedupe.clustering.RefineClusterImpl.createGaussPair;
-import static com.bakdata.dedupe.clustering.RefineClusterImpl.triangularNumber;
 import static com.bakdata.dedupe.clustering.RefineClusterImpl.getRandomEdges;
+import static com.bakdata.dedupe.clustering.RefineClusterImpl.triangularNumber;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bakdata.dedupe.candidate_selection.Candidate;
@@ -12,7 +12,6 @@ import com.bakdata.dedupe.classifier.ClassificationResult.ClassificationResultBu
 import com.bakdata.dedupe.classifier.ClassifiedCandidate;
 import com.bakdata.dedupe.classifier.Classifier;
 import com.bakdata.dedupe.clustering.RefineClusterImpl.WeightedEdge;
-import com.google.common.primitives.Bytes;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -186,14 +185,14 @@ class RefineClusterImplTest {
         final Cluster<Long, Integer> cluster = new Cluster<>(1L, List.of(1, 2, 3, 4, 5));
         // Note: Greedy clustering is sensitive to the order, in which edges are added.
         // Changing the order may lead to different results.
-        final int[] bytes = greedyClustering.greedyCluster(cluster, List.of(
+        final int[] ints = greedyClustering.greedyCluster(cluster, List.of(
                 WeightedEdge.of(0, 1, 1.0),
                 WeightedEdge.of(2, 3, 1.0),
                 WeightedEdge.of(3, 4, 1.0),
                 WeightedEdge.of(1, 3, 1.0)
         ));
 
-        final List<Integer> actual = Arrays.stream(bytes).boxed().collect(Collectors.toList());
+        final List<Integer> actual = Arrays.stream(ints).boxed().collect(Collectors.toList());
         assertThat(actual).isEqualTo(List.of(0, 0, 0, 0, 0));
     }
 
@@ -203,13 +202,13 @@ class RefineClusterImplTest {
         final RefineClusterImpl.GreedyClustering<Long, Integer> greedyClustering = new RefineClusterImpl.GreedyClustering<>();
 
         final Cluster<Long, Integer> cluster = new Cluster<>(1L, List.of(1, 2, 3, 4, 5));
-        final int[] bytes = greedyClustering.greedyCluster(cluster, List.of(
+        final int[] ints = greedyClustering.greedyCluster(cluster, List.of(
                 WeightedEdge.of(0, 1, 1.0),
                 WeightedEdge.of(2, 4, 1.0),
                 WeightedEdge.of(1, 3, 1.0)
         ));
 
-        final List<Integer> actual = Arrays.stream(bytes).boxed().collect(Collectors.toList());
+        final List<Integer> actual = Arrays.stream(ints).boxed().collect(Collectors.toList());
         assertThat(actual).isEqualTo(List.of(0, 0, 2, 0, 2));
     }
 


### PR DESCRIPTION
Previously, Dedupe has not been able to refine clusters with more than 128 elements, since the bytes that represented internal cluster ids overflew. This PR replaces the usage of Bytes with Integers. 